### PR TITLE
Improved notation consistency on invgauss pdf

### DIFF
--- a/man/InvGauss.Rd
+++ b/man/InvGauss.Rd
@@ -19,8 +19,8 @@ random generation.
 The inverse Gaussian distribution has density
 \deqn{
 f(y) =
-\frac{1}{\sqrt{2\pi\sigma y^3}} e^{-(y-\mu)^2/(2 y \sigma m^2)}}{
-f(y) = 1/sqrt(2 pi s y^3) e^-((y - m)^2/(2 y s m^2))}
+\frac{1}{\sqrt{2\pi\sigma y^3}} e^{-(y-\mu)^2/(2 y \sigma \mu^2)}}{
+f(y) = 1/sqrt(2 pi s y^3) e^-((y - \mu)^2/(2 y s \mu^2))}
 where \eqn{\mu}{m} is the mean of the distribution and
 \eqn{\sigma}{s} is the dispersion.
 }


### PR DESCRIPTION
I am trying to better understand the parameterization used in this function, so every bit of improved consistency helps. The PDF equation here uses both \mu and m, and later basically clarifies that \mu = m, so I think it's best to use only one of them in the equation. I'm still not convinced that \sigma = s, but that's topic for a different issue/PR.